### PR TITLE
feature(ReactIo): Smart default react-stdio path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ReactPhoenix
 
 [![Build Status](https://travis-ci.org/geolessel/react-phoenix.svg?branch=master)](https://travis-ci.org/geolessel/react-phoenix)
+[![Hex.pm](https://img.shields.io/hexpm/v/react_phoenix.svg)](https://hex.pm/packages/react_phoenix)
 
 Functions to make rendering React.js components easy in Phoenix.
 
@@ -33,7 +34,7 @@ dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:react_phoenix, "~> 0.4.0"}]
+  [{:react_phoenix, "~> 0.4.1"}]
 end
 ```
 

--- a/lib/react_phoenix/react_io.ex
+++ b/lib/react_phoenix/react_io.ex
@@ -1,5 +1,5 @@
 defmodule ReactPhoenix.ReactIo do
   @moduledoc false
 
-  use StdJsonIo, otp_app: :react_phoenix, script: Application.get_env(:react_phoenix, :react_stdio_path, "node_modules/.bin/react-stdio")
+  use StdJsonIo, otp_app: :react_phoenix, script: Application.get_env(:react_phoenix, :react_stdio_path, ReactPhoenix.ReactIo.PathFinder.react_stdio_path())
 end

--- a/lib/react_phoenix/react_io/path_finder.ex
+++ b/lib/react_phoenix/react_io/path_finder.ex
@@ -1,0 +1,21 @@
+defmodule ReactPhoenix.ReactIo.PathFinder do
+  @moduledoc false
+  @phoenix_1_3_react_stdio_path Path.join(~w(.. .. assets node_modules .bin react-stdio))
+  @phoenix_1_2_react_stdio_path Path.join(~w(.. .. node_modules .bin react-stdio))
+  @local_react_stdio_path Path.join(~w(node_modules .bin react-stdio))
+
+  def react_stdio_path(), do: react_stdio_path(default_locations())
+  def react_stdio_path(locations) when is_list(locations), do: do_react_stdio_path(locations)
+
+  def do_react_stdio_path([]), do: raise("#{ReactPhoenix}: An installation of react-stdio cannot be found. Please run `npm install` and/or set the :react_stdio_path config value for :react_pheonix in your application.")
+  def do_react_stdio_path([location | rest]) do
+    case File.exists?(location) do
+      true -> location
+      false -> do_react_stdio_path(rest)
+    end
+  end
+
+  defp default_locations do
+    [@phoenix_1_3_react_stdio_path, @phoenix_1_2_react_stdio_path, @local_react_stdio_path]
+  end
+end

--- a/lib/react_phoenix/server_side.ex
+++ b/lib/react_phoenix/server_side.ex
@@ -44,7 +44,12 @@ defmodule ReactPhoenix.ServerSide do
   This tells our renderer to look for the component in the
   `priv/static/js/components` directory of our project.
 
-  Additionally, you may need to specify the route of your react-stdio module
+  #### Custom react-stdio location
+
+  _If you are using a standard Phoenix 1.2 or 1.3 app structure, you can
+  skip this section._
+
+  You may need to specify the route of your react-stdio module
   if your node_modules directory does not live in the root directory of your
   project *(if your ReactPhoenix project lives within an umbrella project, for example)*.
 
@@ -56,6 +61,10 @@ defmodule ReactPhoenix.ServerSide do
     # defaults to node_modules/.bin/react-stdio
     react_stdio_path: Path.join(["path_to_your_app", "node_modules", ".bin", "react-stdio"])
   ```
+
+  Then run `mix deps.clean react_phoenix && mix deps.get`.
+
+  #### Set up the watcher
 
   Configure your Endpoint to watch for new component files and compile them
   down as it finds them (but only in dev). If you have a standard Phoenix

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ReactPhoenix.Mixfile do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.4.1"
   @source_url "https://github.com/geolessel/react-phoenix"
 
   def project do

--- a/test/react_phoenix/react_io/path_finder_test.exs
+++ b/test/react_phoenix/react_io/path_finder_test.exs
@@ -1,0 +1,13 @@
+defmodule ReactPhoenix.ReactIo.PathFinderTest do
+  use ExUnit.Case
+  import ReactPhoenix.ReactIo.PathFinder
+
+  test "react_stdio_path returns the first existing file" do
+    assert react_stdio_path(["test", "does_not_exist"]) == "test"
+    assert react_stdio_path(["does_not_exist", "test"]) == "test"
+  end
+
+  test "react_stdio_path raises an error if no location is found" do
+    assert_raise RuntimeError, fn -> react_stdio_path([]) end
+  end
+end


### PR DESCRIPTION
If :react_pheonix :react_stdio_path config not set, then this will
look for react-stdio in the default locations for phoenix 1.3 and 1.2