### PR TITLE
Allow the package to compile without react-stdio presence at compile time

### DIFF
--- a/lib/react_phoenix/react_io.ex
+++ b/lib/react_phoenix/react_io.ex
@@ -1,5 +1,7 @@
 defmodule ReactPhoenix.ReactIo do
   @moduledoc false
 
-  use StdJsonIo, otp_app: :react_phoenix, script: Application.get_env(:react_phoenix, :react_stdio_path, ReactPhoenix.ReactIo.PathFinder.react_stdio_path())
+  use StdJsonIo,
+    otp_app: :react_phoenix,
+    script: (Application.get_env(:react_phoenix, :react_stdio_path) || ReactPhoenix.ReactIo.PathFinder.react_stdio_path())
 end

--- a/lib/react_phoenix/react_io/path_finder.ex
+++ b/lib/react_phoenix/react_io/path_finder.ex
@@ -12,11 +12,11 @@ defmodule ReactPhoenix.ReactIo.PathFinder do
 
   defp do_react_stdio_path([]) do
     "#{ReactPhoenix}: An installation of react-stdio cannot be found. "
-      <> "Please run `npm install` and/or set the :react_stdio_path config value for :react_pheonix in your application. "
-      <> "Then RECOMPILE this package (`mix deps.clean react_phoenix && mix deps.compile`). "
-      <> "Server-side rendering won't work until you fix this issue. "
-      <> "If you only use client-side rendering, you can ignore this."
-    |> Logger.warn
+    <> "Please run `npm install` and/or set the :react_stdio_path config value for :react_pheonix in your application. "
+    <> "Then RECOMPILE this package (`mix deps.clean react_phoenix && mix deps.compile`). "
+    <> "Server-side rendering won't work until you fix this issue. "
+    <> "If you only use client-side rendering, you can ignore this."
+    |> Logger.warn()
     nil
   end
   defp do_react_stdio_path([location | rest]) do

--- a/lib/react_phoenix/react_io/path_finder.ex
+++ b/lib/react_phoenix/react_io/path_finder.ex
@@ -8,7 +8,11 @@ defmodule ReactPhoenix.ReactIo.PathFinder do
   def react_stdio_path(), do: react_stdio_path(default_locations())
   def react_stdio_path(locations) when is_list(locations), do: do_react_stdio_path(locations)
 
-  defp do_react_stdio_path([]), do: raise("#{ReactPhoenix}: An installation of react-stdio cannot be found. Please run `npm install` and/or set the :react_stdio_path config value for :react_pheonix in your application.")
+  defp do_react_stdio_path([]) do
+    msg = "#{ReactPhoenix}: An installation of react-stdio cannot be found. Please run `npm install` and/or set the :react_stdio_path config value for :react_pheonix in your application.  Then RECOMPILE this package (mix deps.clean react_phoenix && mix deps.compile).  Server-side rendering won't work until you fix this issue.  If you only use client-side rendering, you can ignore this."
+    IO.warn(msg, Macro.Env.stacktrace(__ENV__))
+    nil
+  end
   defp do_react_stdio_path([location | rest]) do
     case File.exists?(location) do
       true -> location

--- a/lib/react_phoenix/react_io/path_finder.ex
+++ b/lib/react_phoenix/react_io/path_finder.ex
@@ -11,8 +11,12 @@ defmodule ReactPhoenix.ReactIo.PathFinder do
   def react_stdio_path(locations) when is_list(locations), do: do_react_stdio_path(locations)
 
   defp do_react_stdio_path([]) do
-    msg = "#{ReactPhoenix}: An installation of react-stdio cannot be found. Please run `npm install` and/or set the :react_stdio_path config value for :react_pheonix in your application.  Then RECOMPILE this package (mix deps.clean react_phoenix && mix deps.compile).  Server-side rendering won't work until you fix this issue.  If you only use client-side rendering, you can ignore this."
-    Logger.warn(msg)
+    "#{ReactPhoenix}: An installation of react-stdio cannot be found. "
+      <> "Please run `npm install` and/or set the :react_stdio_path config value for :react_pheonix in your application. "
+      <> "Then RECOMPILE this package (`mix deps.clean react_phoenix && mix deps.compile`). "
+      <> "Server-side rendering won't work until you fix this issue. "
+      <> "If you only use client-side rendering, you can ignore this."
+    |> Logger.warn
     nil
   end
   defp do_react_stdio_path([location | rest]) do

--- a/lib/react_phoenix/react_io/path_finder.ex
+++ b/lib/react_phoenix/react_io/path_finder.ex
@@ -5,12 +5,14 @@ defmodule ReactPhoenix.ReactIo.PathFinder do
   @phoenix_1_2_react_stdio_path Path.join(~w(#{@app_dir} .. .. node_modules .bin react-stdio))
   @local_react_stdio_path Path.join(~w(node_modules .bin react-stdio))
 
+  require Logger
+
   def react_stdio_path(), do: react_stdio_path(default_locations())
   def react_stdio_path(locations) when is_list(locations), do: do_react_stdio_path(locations)
 
   defp do_react_stdio_path([]) do
     msg = "#{ReactPhoenix}: An installation of react-stdio cannot be found. Please run `npm install` and/or set the :react_stdio_path config value for :react_pheonix in your application.  Then RECOMPILE this package (mix deps.clean react_phoenix && mix deps.compile).  Server-side rendering won't work until you fix this issue.  If you only use client-side rendering, you can ignore this."
-    IO.warn(msg, Macro.Env.stacktrace(__ENV__))
+    Logger.warn(msg)
     nil
   end
   defp do_react_stdio_path([location | rest]) do

--- a/test/react_phoenix/react_io/path_finder_test.exs
+++ b/test/react_phoenix/react_io/path_finder_test.exs
@@ -1,6 +1,7 @@
 defmodule ReactPhoenix.ReactIo.PathFinderTest do
   use ExUnit.Case
   import ReactPhoenix.ReactIo.PathFinder
+  import ExUnit.CaptureLog
 
   test "react_stdio_path returns the first existing file" do
     assert react_stdio_path(["test", "does_not_exist"]) == "test"
@@ -8,6 +9,9 @@ defmodule ReactPhoenix.ReactIo.PathFinderTest do
   end
 
   test "react_stdio_path returns nil if no location is found" do
-    assert react_stdio_path([]) == nil
+    log_msg = capture_log(fn() ->
+      assert react_stdio_path([]) == nil
+    end)
+    assert log_msg =~ "react-stdio cannot be found"
   end
 end

--- a/test/react_phoenix/react_io/path_finder_test.exs
+++ b/test/react_phoenix/react_io/path_finder_test.exs
@@ -7,7 +7,7 @@ defmodule ReactPhoenix.ReactIo.PathFinderTest do
     assert react_stdio_path(["does_not_exist", "test"]) == "test"
   end
 
-  test "react_stdio_path raises an error if no location is found" do
-    assert_raise RuntimeError, fn -> react_stdio_path([]) end
+  test "react_stdio_path returns nil if no location is found" do
+    assert react_stdio_path([]) == nil
   end
 end


### PR DESCRIPTION
This fixes https://github.com/geolessel/react-phoenix/issues/17 in a couple of ways:

- When the `react_stdio_path` is set, we don't even look at the default paths.
- When `react-stdio` can't be found in the default paths, then we print a warning instead of raising an error.  

