### PR TITLE
Add an ability to set the NODE_PATH env var via :node_modules_path option. Fixes #10

### DIFF
--- a/lib/react_phoenix/react_io.ex
+++ b/lib/react_phoenix/react_io.ex
@@ -1,7 +1,18 @@
 defmodule ReactPhoenix.ReactIo do
   @moduledoc false
-
-  use StdJsonIo,
-    otp_app: :react_phoenix,
-    script: (Application.get_env(:react_phoenix, :react_stdio_path) || ReactPhoenix.ReactIo.PathFinder.react_stdio_path())
+  use StdJsonIo, otp_app: :react_phoenix,
+    script: fn ->
+      react_stdio_path = (Application.get_env(:react_phoenix, :react_stdio_path) || ReactPhoenix.ReactIo.PathFinder.react_stdio_path())
+      case Application.get_env(:react_phoenix, :node_modules_path) do
+        nil ->
+          react_stdio_path
+        node_modules_path ->
+          Enum.join([
+            "NODE_PATH=",
+            node_modules_path,
+            " ",
+            react_stdio_path
+          ])
+      end
+    end.()
 end


### PR DESCRIPTION
I have written a solution about the problem, but I'm а newbie in the Elixir lang and I'm not sure 
that my resolution of the problem is very proper.
The problem was that the react-stdio wasn't able to find the node_modules directory.
The occurred error wasn't very clear:

> Failed to call to json service Elixir.ReactPhoenix.ReactIo Cannot load component

After some debugging time I figured out that react-stdio cannot find node modules at all.
It was actually seeking for node_modules in the root directory(as it is in Phoenix 1.2) of the project 
instead of assets/node_modules(as it is in Phoenix 1.3).

I added an option called :node_modules_path that allows you to customize node_modules location.

**Example**: 
```
config :react_phoenix,
  compiled_path: Path.join(["priv", "static", "js", "components"]),
  node_modules_path: Path.join(["assets", "node_modules"]) # <-- ADD THIS

```