### PR TITLE
remove application module callback

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,8 +17,7 @@ defmodule ReactPhoenix.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :phoenix_html, :poison],
-     mod: []]
+    [applications: [:logger, :phoenix_html, :poison],]
   end
 
   def description do


### PR DESCRIPTION
Removes application module callback, because with the changes of this version it's not necessary and throws an error when you try to make a release.

closes #26 